### PR TITLE
prefix削除方法の変更とjsonにkeyが存在しなかった時にエラーを吐かないようにする

### DIFF
--- a/test.py
+++ b/test.py
@@ -17,9 +17,12 @@ async def on_message(message):
     prefix = "%"
 
     if message.content.startswith(prefix):
-        with open('./bot_db.json') as reply_db:
-            receive_ms = message.content
-            reply = json.load(reply_db)[receive_ms.replace(prefix,'')]
+        receive_ms = message.content
+        with open('./bot_db.json') as f:
+            reply_db = json.load(f)
+        reply = reply_db.get(receive_ms[len(prefix):])
+        if reply is None:
+            reply = "未登録" #もしdbにkeyが存在しなかったときに返す言葉
         await message.channel.send(reply)
         print("send succses:" + reply)
 


### PR DESCRIPTION
### prefix削除方法の変更
prefixの削除方法をreplaceからスライスにすることで間にプレフィックスと同じ文字が入っていても正しく認識できるようにする

### jsonにkeyが存在しなかった時にエラーを吐かないようにする
jsonにkeyが存在しなかった時にエラーを吐くのでget関数を使って対応